### PR TITLE
docs(ui): UI 설계 문서 및 pre-commit 훅 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -324,3 +324,5 @@ CLAUDE.md
 .claude/
 .mcp.*
 temp/
+# Next.js lib directory (override Python rule)
+!lib/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+.next
+node_modules
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "printWidth": 100
+}

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -8,90 +8,105 @@
 
 ### 1.1 브랜치 네이밍
 
-| 브랜치 유형 | 네이밍 패턴 | 설명 |
-|------------|------------|------|
-| 메인 | `main` | 프로덕션 배포 브랜치 |
-| 개발 | `develop` | 개발 통합 브랜치 |
-| 기능 | `feature/{기능명}` | 새로운 기능 개발 |
-| 버그 수정 | `fix/{버그명}` | 버그 수정 |
-| 릴리스 | `release-{버전}` | 릴리스 준비 |
-| 핫픽스 | `hotfix/{이슈명}` | 긴급 수정 |
+| 브랜치 유형 | 네이밍 패턴                    | 설명                 |
+| ----------- | ------------------------------ | -------------------- |
+| 메인        | `main`                         | 프로덕션 배포 브랜치 |
+| 개발        | `develop`                      | 개발 통합 브랜치     |
+| 기능        | `feature/{기능명}-#{이슈번호}` | 새로운 기능 개발     |
+| 버그 수정   | `fix/{버그명}-#{이슈번호}`     | 버그 수정            |
+| 문서        | `docs/{문서명}-#{이슈번호}`    | 문서 작성/수정       |
+| 릴리스      | `release-{버전}`               | 릴리스 준비          |
+| 핫픽스      | `hotfix/{이슈명}-#{이슈번호}`  | 긴급 수정            |
+
+> **Note**: 이슈 번호는 항상 브랜치명 맨 뒤에 `#`과 함께 위치합니다. GitHub 이슈와 연결하여 작업 추적이 용이합니다.
 
 **예시:**
-- `feature/email-classification`
-- `fix/folder-tree-rendering`
+
+- `feature/email-classification-#42`
+- `fix/folder-tree-rendering-#58`
+- `docs/ui-spec-#1`
 - `release-1.0.0`
+- `hotfix/login-error-#99`
 
 ### 1.2 커밋 메시지 (Conventional Commits)
 
 #### 기본 형식
+
 ```
 <type>(<scope>): <subject>
 
 <body>
 
-<jira-issue>
+<github-issue>
 ```
 
 #### Type (필수)
-| Type | 설명 | 예시 |
-|------|------|------|
-| `feat` | 새로운 기능 추가 | 메일 분류 API 추가 |
-| `fix` | 버그 수정 | 폴더 트리 렌더링 오류 수정 |
-| `docs` | 문서 변경 | README 업데이트 |
-| `style` | 코드 포맷팅, 세미콜론 누락 등 (동작 변경 없음) | 들여쓰기 수정 |
-| `refactor` | 코드 리팩토링 (기능 변경 없음) | 함수 분리 |
-| `test` | 테스트 추가/수정 | 분류 로직 단위 테스트 추가 |
-| `chore` | 빌드, 설정, 패키지 등 기타 변경 | 의존성 업데이트 |
-| `perf` | 성능 개선 | 쿼리 최적화 |
-| `ci` | CI/CD 설정 변경 | GitHub Actions 추가 |
+
+| Type       | 설명                                           | 예시                       |
+| ---------- | ---------------------------------------------- | -------------------------- |
+| `feat`     | 새로운 기능 추가                               | 메일 분류 API 추가         |
+| `fix`      | 버그 수정                                      | 폴더 트리 렌더링 오류 수정 |
+| `docs`     | 문서 변경                                      | README 업데이트            |
+| `style`    | 코드 포맷팅, 세미콜론 누락 등 (동작 변경 없음) | 들여쓰기 수정              |
+| `refactor` | 코드 리팩토링 (기능 변경 없음)                 | 함수 분리                  |
+| `test`     | 테스트 추가/수정                               | 분류 로직 단위 테스트 추가 |
+| `chore`    | 빌드, 설정, 패키지 등 기타 변경                | 의존성 업데이트            |
+| `perf`     | 성능 개선                                      | 쿼리 최적화                |
+| `ci`       | CI/CD 설정 변경                                | GitHub Actions 추가        |
 
 #### Scope (선택)
+
 프로젝트 내 영향 받는 영역을 명시합니다.
 
-| Scope | 설명 |
-|-------|------|
-| `api` | 백엔드 API 관련 |
-| `ui` | 프론트엔드 UI 관련 |
-| `classification` | 메일 분류 로직 |
-| `folder` | 폴더 관리 기능 |
-| `db` | 데이터베이스 관련 |
-| `auth` | 인증/권한 관련 |
-| `config` | 설정 파일 관련 |
+| Scope            | 설명               |
+| ---------------- | ------------------ |
+| `api`            | 백엔드 API 관련    |
+| `ui`             | 프론트엔드 UI 관련 |
+| `classification` | 메일 분류 로직     |
+| `folder`         | 폴더 관리 기능     |
+| `db`             | 데이터베이스 관련  |
+| `auth`           | 인증/권한 관련     |
+| `config`         | 설정 파일 관련     |
 
 #### Subject (필수) - 제목 규칙
+
 - **50자 이내**로 작성
 - **한글** 사용 (영어도 허용)
 - 첫 글자 대문자 X, 마침표 X
 - **명령형**으로 작성: "추가한다" (O), "추가했음" (X), "추가" (O)
 
 #### Body (선택) - 본문 규칙
+
 - 제목과 본문 사이 **빈 줄 1개** 필수
 - **72자마다 줄바꿈** 권장
 - **무엇을, 왜** 변경했는지 설명 (어떻게는 코드로)
 - 글머리 기호(`-`) 사용 가능
 
-#### Jira 이슈 연동 (권장)
-커밋과 Jira 이슈를 연결하여 트래킹합니다.
+#### GitHub 이슈 연동 (권장)
 
-| 형식 | 용도 | 예시 |
-|------|------|------|
-| `PIG-{번호}` | 이슈 참조 | `PIG-123` |
-| `Closes PIG-{번호}` | 이슈 완료 처리 | `Closes PIG-123` |
-| `Refs PIG-{번호}` | 관련 이슈 참조 | `Refs PIG-45, PIG-67` |
+커밋과 GitHub 이슈를 연결하여 트래킹합니다.
 
-> **Note**: `PIG`는 Pigeon 프로젝트의 Jira 프로젝트 키입니다. 실제 프로젝트 키에 맞게 변경하세요.
+| 형식             | 용도                                  | 예시            |
+| ---------------- | ------------------------------------- | --------------- |
+| `#{번호}`        | 이슈 참조                             | `#123`          |
+| `Closes #{번호}` | 이슈 완료 처리 (PR 머지 시 자동 종료) | `Closes #123`   |
+| `Fixes #{번호}`  | 버그 이슈 완료 처리                   | `Fixes #123`    |
+| `Refs #{번호}`   | 관련 이슈 참조                        | `Refs #45, #67` |
+
+> **Note**: GitHub에서는 `Closes`, `Fixes`, `Resolves` 키워드를 사용하면 PR 머지 시 해당 이슈가 자동으로 닫힙니다.
 
 #### 커밋 메시지 예시
 
 **간단한 커밋:**
+
 ```
 feat(classification): LLM 기반 메일 분류 로직 추가
 
-PIG-42
+#42
 ```
 
 **상세한 커밋:**
+
 ```
 feat(classification): LLM 기반 메일 분류 로직 추가
 
@@ -99,27 +114,29 @@ feat(classification): LLM 기반 메일 분류 로직 추가
 - 폴더 경로 추천 알고리즘 구현
 - 분류 결과 캐싱 적용
 
-Closes PIG-42
+Closes #42
 ```
 
 **버그 수정:**
+
 ```
 fix(ui): 폴더 트리 렌더링 오류 수정
 
 깊이 3 이상의 폴더가 표시되지 않는 문제 해결
 재귀 렌더링 로직 수정
 
-Closes PIG-58
+Fixes #58
 ```
 
 **여러 이슈 관련:**
+
 ```
 refactor(api): 메일 분류 API 응답 형식 변경
 
 BREAKING CHANGE: 기존 `category` 필드가 `folderPath`로 변경됨
 
-Refs PIG-100, PIG-101
-Closes PIG-99
+Refs #100, #101
+Closes #99
 ```
 
 #### 잘못된 커밋 메시지 예시
@@ -137,7 +154,7 @@ feat(api): 메일 분류 API를 추가했습니다
 # Bad: 마침표 사용
 feat(api): 메일 분류 API 추가.
 
-# Bad: Jira 이슈 번호 없음 (트래킹 불가)
+# Bad: GitHub 이슈 번호 없음 (트래킹 불가)
 feat(api): 메일 분류 API 추가
 ```
 
@@ -147,30 +164,32 @@ feat(api): 메일 분류 API 추가
 
 ### 2.1 일반 규칙
 
-| 대상 | 규칙 | 예시 |
-|------|------|------|
-| 디렉토리 | kebab-case | `email-service`, `folder-tree` |
-| Python 파일 | snake_case | `email_classifier.py`, `folder_manager.py` |
-| TypeScript/JS 파일 | camelCase 또는 PascalCase (컴포넌트) | `emailService.ts`, `FolderTree.tsx` |
-| 테스트 파일 | `test_*.py` 또는 `*.test.ts` | `test_classifier.py`, `FolderTree.test.tsx` |
+| 대상               | 규칙                                 | 예시                                        |
+| ------------------ | ------------------------------------ | ------------------------------------------- |
+| 디렉토리           | kebab-case                           | `email-service`, `folder-tree`              |
+| Python 파일        | snake_case                           | `email_classifier.py`, `folder_manager.py`  |
+| TypeScript/JS 파일 | camelCase 또는 PascalCase (컴포넌트) | `emailService.ts`, `FolderTree.tsx`         |
+| 테스트 파일        | `test_*.py` 또는 `*.test.ts`         | `test_classifier.py`, `FolderTree.test.tsx` |
 
 ### 2.2 문서 파일
 
-| 대상 | 규칙 | 예시 |
-|------|------|------|
-| 마크다운 | UPPER_SNAKE_CASE | `README.md`, `CONVENTIONS.md` |
-| 기능 문서 | `[기능명] 문서명` 형식 | `[메일분류] API명세.md` |
+| 대상      | 규칙                   | 예시                          |
+| --------- | ---------------------- | ----------------------------- |
+| 마크다운  | UPPER_SNAKE_CASE       | `README.md`, `CONVENTIONS.md` |
+| 기능 문서 | `[기능명] 문서명` 형식 | `[메일분류] API명세.md`       |
 
 ---
 
 ## 3. 코드 스타일
 
 ### 3.1 Python
+
 - PEP 8 준수
 - 타입 힌트 사용 권장
 - docstring: Google 스타일
 
 ### 3.2 TypeScript/JavaScript
+
 - ESLint + Prettier 적용
 - 함수형 컴포넌트 + Hooks 사용 (React)
 
@@ -179,18 +198,22 @@ feat(api): 메일 분류 API 추가
 ## 4. PR 및 코드 리뷰
 
 ### 4.1 PR 제목
+
 커밋 메시지와 동일한 Conventional Commits 형식 사용
 
 ### 4.2 PR 본문
+
 ```markdown
 ## Summary
+
 - 변경 사항 요약
 
 ## Test Plan
+
 - [ ] 테스트 항목 1
 - [ ] 테스트 항목 2
 ```
 
 ---
 
-*이 문서는 프로젝트 진행에 따라 업데이트됩니다.*
+_이 문서는 프로젝트 진행에 따라 업데이트됩니다._

--- a/docs/UI_SPEC.md
+++ b/docs/UI_SPEC.md
@@ -1,0 +1,632 @@
+# Pigeon UI 설계 문서
+
+> **작성일**: 2025-12-10
+> **버전**: v1.0
+> **상태**: Draft
+> **관련 이슈**: #1
+
+---
+
+## 1. 개요
+
+Pigeon은 AI 기반 메일 분류 시스템으로, 사용자가 메일을 효율적으로 관리할 수 있는 직관적인 UI를 제공합니다.
+
+### 1.1 디자인 원칙
+
+- **심플함**: 필수 기능에 집중한 깔끔한 인터페이스
+- **직관성**: 메일 클라이언트에 익숙한 3단 레이아웃
+- **반응성**: 실시간 동기화 상태 및 분류 진행 표시
+
+---
+
+## 2. 화면 구성
+
+### 2.1 전체 레이아웃
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Header (로고, 사용자 정보, 동기화 버튼)                          │
+├────────────┬─────────────────────┬──────────────────────────────┤
+│            │                     │                              │
+│  Sidebar   │     Mail List       │       Mail Detail            │
+│  (폴더트리) │     (메일 목록)       │       (메일 상세)             │
+│            │                     │                              │
+│  240px     │      360px          │         flex-1               │
+│            │                     │                              │
+├────────────┴─────────────────────┴──────────────────────────────┤
+│  StatusBar (동기화 상태, 메일 수, 마지막 확인 시간)                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 페이지 구조
+
+| 경로         | 페이지      | 설명                       |
+| ------------ | ----------- | -------------------------- |
+| `/`          | 랜딩 페이지 | 서비스 소개 및 로그인 유도 |
+| `/login`     | 로그인      | Gmail OAuth 연동           |
+| `/callback`  | OAuth 콜백  | 인증 처리 후 리다이렉트    |
+| `/mail`      | 메일함      | 메인 3단 레이아웃          |
+| `/mail/[id]` | 메일 상세   | 특정 메일 상세 보기        |
+
+---
+
+## 3. 컴포넌트 설계
+
+### 3.1 컴포넌트 계층 구조
+
+```
+app/
+├── layout.tsx                 # 루트 레이아웃
+├── page.tsx                   # 랜딩 페이지
+│
+├── (auth)/
+│   ├── login/page.tsx         # 로그인 페이지
+│   └── callback/page.tsx      # OAuth 콜백
+│
+└── (main)/
+    ├── layout.tsx             # 3단 레이아웃
+    └── mail/
+        ├── page.tsx           # 메일 목록
+        └── [id]/page.tsx      # 메일 상세
+
+components/
+├── ui/                        # 기본 UI 컴포넌트
+│   ├── Button.tsx
+│   ├── Input.tsx
+│   ├── Modal.tsx
+│   ├── Skeleton.tsx
+│   └── Badge.tsx
+│
+├── layout/                    # 레이아웃 컴포넌트
+│   ├── Header.tsx
+│   ├── Sidebar.tsx
+│   └── StatusBar.tsx
+│
+├── mail/                      # 메일 관련 컴포넌트
+│   ├── MailList.tsx
+│   ├── MailListItem.tsx
+│   ├── MailDetail.tsx
+│   └── MailActions.tsx
+│
+└── folder/                    # 폴더 관련 컴포넌트
+    ├── FolderTree.tsx
+    ├── FolderTreeItem.tsx
+    └── FolderBadge.tsx
+```
+
+### 3.2 주요 컴포넌트 명세
+
+#### Header
+
+```typescript
+interface HeaderProps {
+  user: User | null;
+  onSync: () => void;
+  onLogout: () => void;
+  isSyncing: boolean;
+}
+```
+
+#### FolderTree
+
+```typescript
+interface FolderTreeProps {
+  folders: Folder[];
+  selectedFolderId: string | null;
+  onSelectFolder: (folderId: string) => void;
+}
+```
+
+#### MailList
+
+```typescript
+interface MailListProps {
+  mails: Mail[];
+  selectedMailId: string | null;
+  onSelectMail: (mailId: string) => void;
+  isLoading: boolean;
+}
+```
+
+#### MailDetail
+
+```typescript
+interface MailDetailProps {
+  mail: Mail | null;
+  onMove: (folderId: string) => void;
+  onDelete: () => void;
+}
+```
+
+---
+
+## 4. 목업 데이터
+
+### 4.1 사용자 (User)
+
+```typescript
+interface User {
+  id: string;
+  email: string;
+  name: string;
+  profileImage?: string;
+}
+
+// 목업 데이터
+const mockUser: User = {
+  id: 'user-1',
+  email: 'user@example.com',
+  name: '홍길동',
+  profileImage: 'https://via.placeholder.com/40',
+};
+```
+
+### 4.2 폴더 (Folder)
+
+```typescript
+interface Folder {
+  id: string;
+  name: string;
+  path: string;
+  parentId: string | null;
+  unreadCount: number;
+  children?: Folder[];
+}
+
+// 목업 데이터
+const mockFolders: Folder[] = [
+  {
+    id: 'folder-1',
+    name: '업무',
+    path: '/업무',
+    parentId: null,
+    unreadCount: 12,
+    children: [
+      {
+        id: 'folder-1-1',
+        name: '프로젝트A',
+        path: '/업무/프로젝트A',
+        parentId: 'folder-1',
+        unreadCount: 5,
+        children: [],
+      },
+      {
+        id: 'folder-1-2',
+        name: '프로젝트B',
+        path: '/업무/프로젝트B',
+        parentId: 'folder-1',
+        unreadCount: 7,
+        children: [],
+      },
+    ],
+  },
+  {
+    id: 'folder-2',
+    name: '개인',
+    path: '/개인',
+    parentId: null,
+    unreadCount: 3,
+    children: [
+      {
+        id: 'folder-2-1',
+        name: '쇼핑',
+        path: '/개인/쇼핑',
+        parentId: 'folder-2',
+        unreadCount: 3,
+        children: [],
+      },
+    ],
+  },
+  {
+    id: 'folder-3',
+    name: '뉴스레터',
+    path: '/뉴스레터',
+    parentId: null,
+    unreadCount: 8,
+    children: [],
+  },
+  {
+    id: 'folder-4',
+    name: '미분류',
+    path: '/미분류',
+    parentId: null,
+    unreadCount: 2,
+    children: [],
+  },
+];
+```
+
+### 4.3 메일 (Mail)
+
+```typescript
+interface Mail {
+  id: string;
+  subject: string;
+  from: {
+    name: string;
+    email: string;
+  };
+  to: {
+    name: string;
+    email: string;
+  }[];
+  body: string;
+  bodyPreview: string;
+  folderId: string;
+  folderPath: string;
+  isRead: boolean;
+  isStarred: boolean;
+  receivedAt: string;
+  classificationReason?: string;
+}
+
+// 목업 데이터
+const mockMails: Mail[] = [
+  {
+    id: 'mail-1',
+    subject: '[프로젝트A] 주간 회의록 공유드립니다',
+    from: { name: '김팀장', email: 'kim@company.com' },
+    to: [{ name: '홍길동', email: 'user@example.com' }],
+    body: `안녕하세요, 홍길동님
+
+이번 주 회의록을 공유드립니다.
+
+## 주요 논의 사항
+1. 신규 기능 개발 일정 확정
+2. QA 테스트 계획 수립
+3. 다음 스프린트 백로그 정리
+
+## 액션 아이템
+- [ ] 기획서 검토 (홍길동)
+- [ ] API 명세서 작성 (박개발)
+- [ ] 디자인 시안 전달 (이디자인)
+
+감사합니다.`,
+    bodyPreview: '안녕하세요, 홍길동님. 이번 주 회의록을 공유드립니다...',
+    folderId: 'folder-1-1',
+    folderPath: '/업무/프로젝트A',
+    isRead: false,
+    isStarred: true,
+    receivedAt: '2025-12-10T09:30:00Z',
+    classificationReason: '프로젝트A 관련 회의록으로 분류됨',
+  },
+  {
+    id: 'mail-2',
+    subject: 'PR Review 요청: feat/email-classification',
+    from: { name: 'GitHub', email: 'noreply@github.com' },
+    to: [{ name: '홍길동', email: 'user@example.com' }],
+    body: `@developer님이 PR 리뷰를 요청했습니다.
+
+**Pull Request #42**
+feat: LLM 기반 메일 분류 로직 구현
+
+변경 사항:
+- OpenAI API 연동
+- 분류 알고리즘 구현
+- 단위 테스트 추가
+
+[PR 보러가기](https://github.com/example/pigeon/pull/42)`,
+    bodyPreview: '@developer님이 PR 리뷰를 요청했습니다...',
+    folderId: 'folder-1-2',
+    folderPath: '/업무/프로젝트B',
+    isRead: false,
+    isStarred: false,
+    receivedAt: '2025-12-10T08:15:00Z',
+    classificationReason: 'GitHub 알림으로 업무/프로젝트B로 분류됨',
+  },
+  {
+    id: 'mail-3',
+    subject: '주문하신 상품이 배송 완료되었습니다',
+    from: { name: '쿠팡', email: 'no-reply@coupang.com' },
+    to: [{ name: '홍길동', email: 'user@example.com' }],
+    body: `홍길동님, 안녕하세요.
+
+주문하신 상품이 배송 완료되었습니다.
+
+주문번호: 2024121012345
+상품명: 무선 키보드
+배송완료일: 2025-12-10
+
+[배송조회](https://www.coupang.com/tracking/12345)`,
+    bodyPreview: '주문하신 상품이 배송 완료되었습니다...',
+    folderId: 'folder-2-1',
+    folderPath: '/개인/쇼핑',
+    isRead: true,
+    isStarred: false,
+    receivedAt: '2025-12-10T07:00:00Z',
+    classificationReason: '쇼핑몰 배송 알림으로 개인/쇼핑으로 분류됨',
+  },
+  {
+    id: 'mail-4',
+    subject: 'TechNews Weekly #128 - AI 트렌드 총정리',
+    from: { name: 'TechNews', email: 'newsletter@technews.com' },
+    to: [{ name: '홍길동', email: 'user@example.com' }],
+    body: `이번 주 테크 뉴스 하이라이트
+
+## AI 트렌드
+- Claude 4 출시 임박
+- GPT-5 루머 정리
+- 오픈소스 LLM 성능 비교
+
+## 개발자 도구
+- VS Code 새 기능
+- GitHub Copilot 업데이트
+
+[전체 뉴스레터 보기](https://technews.com/weekly/128)`,
+    bodyPreview: '이번 주 테크 뉴스 하이라이트...',
+    folderId: 'folder-3',
+    folderPath: '/뉴스레터',
+    isRead: true,
+    isStarred: false,
+    receivedAt: '2025-12-09T18:00:00Z',
+    classificationReason: '정기 뉴스레터로 분류됨',
+  },
+  {
+    id: 'mail-5',
+    subject: '안녕하세요, 문의드립니다',
+    from: { name: 'Unknown', email: 'unknown@example.org' },
+    to: [{ name: '홍길동', email: 'user@example.com' }],
+    body: `안녕하세요.
+
+일반적인 문의 메일입니다.
+
+감사합니다.`,
+    bodyPreview: '안녕하세요. 일반적인 문의 메일입니다...',
+    folderId: 'folder-4',
+    folderPath: '/미분류',
+    isRead: false,
+    isStarred: false,
+    receivedAt: '2025-12-09T15:30:00Z',
+    classificationReason: '분류 기준에 맞지 않아 미분류로 이동',
+  },
+];
+```
+
+### 4.4 동기화 상태 (SyncStatus)
+
+```typescript
+interface SyncStatus {
+  status: 'idle' | 'syncing' | 'classifying' | 'completed' | 'error';
+  progress: number; // 0-100
+  totalMails: number;
+  processedMails: number;
+  lastSyncAt: string | null;
+  errorMessage?: string;
+}
+
+// 목업 데이터
+const mockSyncStatus: SyncStatus = {
+  status: 'completed',
+  progress: 100,
+  totalMails: 50,
+  processedMails: 50,
+  lastSyncAt: '2025-12-10T10:00:00Z',
+};
+```
+
+---
+
+## 5. 디자인 시스템
+
+### 5.1 색상 팔레트
+
+```css
+:root {
+  /* Primary */
+  --primary-50: #eff6ff;
+  --primary-100: #dbeafe;
+  --primary-500: #3b82f6;
+  --primary-600: #2563eb;
+  --primary-700: #1d4ed8;
+
+  /* Gray */
+  --gray-50: #f9fafb;
+  --gray-100: #f3f4f6;
+  --gray-200: #e5e7eb;
+  --gray-300: #d1d5db;
+  --gray-500: #6b7280;
+  --gray-700: #374151;
+  --gray-900: #111827;
+
+  /* Semantic */
+  --success: #10b981;
+  --warning: #f59e0b;
+  --error: #ef4444;
+  --info: #3b82f6;
+
+  /* Background */
+  --bg-primary: #ffffff;
+  --bg-secondary: #f9fafb;
+  --bg-sidebar: #f3f4f6;
+}
+```
+
+### 5.2 타이포그래피
+
+```css
+:root {
+  --font-sans: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+
+  /* Font Sizes */
+  --text-xs: 0.75rem; /* 12px */
+  --text-sm: 0.875rem; /* 14px */
+  --text-base: 1rem; /* 16px */
+  --text-lg: 1.125rem; /* 18px */
+  --text-xl: 1.25rem; /* 20px */
+  --text-2xl: 1.5rem; /* 24px */
+}
+```
+
+### 5.3 간격 (Spacing)
+
+```css
+:root {
+  --space-1: 0.25rem; /* 4px */
+  --space-2: 0.5rem; /* 8px */
+  --space-3: 0.75rem; /* 12px */
+  --space-4: 1rem; /* 16px */
+  --space-5: 1.25rem; /* 20px */
+  --space-6: 1.5rem; /* 24px */
+  --space-8: 2rem; /* 32px */
+}
+```
+
+### 5.4 컴포넌트 스타일
+
+#### 버튼
+
+```
+Primary: bg-primary-600, text-white, hover:bg-primary-700
+Secondary: bg-gray-100, text-gray-700, hover:bg-gray-200
+Ghost: bg-transparent, text-gray-600, hover:bg-gray-100
+Danger: bg-error, text-white, hover:opacity-90
+```
+
+#### 카드
+
+```
+bg-white, rounded-lg, shadow-sm, border border-gray-200
+```
+
+#### 입력 필드
+
+```
+border border-gray-300, rounded-md, focus:ring-2 focus:ring-primary-500
+```
+
+---
+
+## 6. 상태 관리
+
+### 6.1 Store 구조 (Zustand)
+
+```typescript
+// stores/authStore.ts
+interface AuthStore {
+  user: User | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: () => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+// stores/folderStore.ts
+interface FolderStore {
+  folders: Folder[];
+  selectedFolderId: string | null;
+  isLoading: boolean;
+  fetchFolders: () => Promise<void>;
+  selectFolder: (id: string) => void;
+}
+
+// stores/mailStore.ts
+interface MailStore {
+  mails: Mail[];
+  selectedMailId: string | null;
+  isLoading: boolean;
+  fetchMails: (folderId?: string) => Promise<void>;
+  selectMail: (id: string) => void;
+  markAsRead: (id: string) => Promise<void>;
+  deleteMail: (id: string) => Promise<void>;
+  moveMail: (id: string, folderId: string) => Promise<void>;
+}
+
+// stores/syncStore.ts
+interface SyncStore {
+  status: SyncStatus;
+  startSync: () => Promise<void>;
+  pollStatus: () => Promise<void>;
+}
+```
+
+---
+
+## 7. 와이어프레임
+
+### 7.1 랜딩 페이지 (`/`)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                         Header                               │
+│  🕊️ Pigeon                              [Gmail로 시작하기]   │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│                    🕊️                                       │
+│              AI 메일 폴더링                                  │
+│                                                             │
+│     LLM이 당신의 메일을 자동으로 분류해드립니다               │
+│                                                             │
+│              [ Gmail로 시작하기 ]                            │
+│                                                             │
+│  ┌─────────┐  ┌─────────┐  ┌─────────┐                     │
+│  │ 자동분류 │  │ 스마트   │  │ 실시간   │                     │
+│  │ AI 기반  │  │ 폴더생성 │  │ 동기화   │                     │
+│  └─────────┘  └─────────┘  └─────────┘                     │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 7.2 메일함 (`/mail`)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 🕊️ Pigeon          🔄 동기화    user@example.com ▼  [로그아웃]   │
+├────────────┬─────────────────────┬──────────────────────────────┤
+│ 📁 폴더    │ 📬 메일목록         │ 📄 메일 상세                  │
+│            │                     │                              │
+│ ▼ 업무 (12)│ ☐ 전체선택  🗑️삭제  │ From: 김팀장                 │
+│   ├ 프로젝A│ ─────────────────── │ To: 홍길동                   │
+│   └ 프로젝B│ ● 주간 회의록...    │ Subject: [프로젝트A] 주간... │
+│ ▼ 개인 (3) │   김팀장 | 09:30    │ ─────────────────────────────│
+│   └ 쇼핑   │ ─────────────────── │                              │
+│ ▶ 뉴스레터 │ ○ PR Review 요청... │ 안녕하세요, 홍길동님         │
+│ ▶ 미분류   │   GitHub | 08:15   │                              │
+│            │ ─────────────────── │ 이번 주 회의록을 공유...     │
+│            │ ○ 배송 완료...      │                              │
+│            │   쿠팡 | 07:00     │ ─────────────────────────────│
+│            │                     │ 📁 업무/프로젝트A            │
+│            │                     │ 💡 프로젝트A 관련 회의록...  │
+│            │                     │                              │
+│            │                     │ [📁이동] [🗑️삭제]            │
+├────────────┴─────────────────────┴──────────────────────────────┤
+│ ✓ 동기화 완료 | 총 50개 메일 | 마지막 확인: 30초 전              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 8. 반응형 설계
+
+### 8.1 브레이크포인트
+
+| 브레이크포인트 | 크기           | 레이아웃                    |
+| -------------- | -------------- | --------------------------- |
+| Mobile         | < 768px        | 단일 패널 (탭 전환)         |
+| Tablet         | 768px - 1024px | 2단 (폴더 + 목록/상세 전환) |
+| Desktop        | > 1024px       | 3단 전체 표시               |
+
+### 8.2 모바일 레이아웃
+
+```
+┌───────────────────────┐
+│ 🕊️ Pigeon    ☰  🔄   │
+├───────────────────────┤
+│ [폴더] [메일] [상세]   │  ← 탭 전환
+├───────────────────────┤
+│                       │
+│  현재 선택된 뷰 표시   │
+│                       │
+└───────────────────────┘
+```
+
+---
+
+## 9. 관련 문서
+
+- [시스템 아키텍처](./ARCHITECTURE.md)
+- [컨벤션 가이드](./CONVENTIONS.md)
+- [기술 결정 기록](./DECISIONS.md)
+
+---
+
+_이 문서는 프로젝트 진행에 따라 지속적으로 업데이트됩니다._

--- a/lib/mock/data.ts
+++ b/lib/mock/data.ts
@@ -1,0 +1,224 @@
+import type { User, Folder, Mail, SyncStatus } from '@/types';
+
+// Mock User
+export const mockUser: User = {
+  id: 'user-1',
+  email: 'user@example.com',
+  name: '홍길동',
+  profileImage: 'https://via.placeholder.com/40',
+};
+
+// Mock Folders
+export const mockFolders: Folder[] = [
+  {
+    id: 'folder-1',
+    name: '업무',
+    path: '/업무',
+    parentId: null,
+    unreadCount: 12,
+    children: [
+      {
+        id: 'folder-1-1',
+        name: '프로젝트A',
+        path: '/업무/프로젝트A',
+        parentId: 'folder-1',
+        unreadCount: 5,
+        children: [],
+      },
+      {
+        id: 'folder-1-2',
+        name: '프로젝트B',
+        path: '/업무/프로젝트B',
+        parentId: 'folder-1',
+        unreadCount: 7,
+        children: [],
+      },
+    ],
+  },
+  {
+    id: 'folder-2',
+    name: '개인',
+    path: '/개인',
+    parentId: null,
+    unreadCount: 3,
+    children: [
+      {
+        id: 'folder-2-1',
+        name: '쇼핑',
+        path: '/개인/쇼핑',
+        parentId: 'folder-2',
+        unreadCount: 3,
+        children: [],
+      },
+    ],
+  },
+  {
+    id: 'folder-3',
+    name: '뉴스레터',
+    path: '/뉴스레터',
+    parentId: null,
+    unreadCount: 8,
+    children: [],
+  },
+  {
+    id: 'folder-4',
+    name: '미분류',
+    path: '/미분류',
+    parentId: null,
+    unreadCount: 2,
+    children: [],
+  },
+];
+
+// Mock Mails
+export const mockMails: Mail[] = [
+  {
+    id: 'mail-1',
+    subject: '[프로젝트A] 주간 회의록 공유드립니다',
+    from: { name: '김팀장', email: 'kim@company.com' },
+    to: [{ name: '홍길동', email: 'user@example.com' }],
+    body: `안녕하세요, 홍길동님
+
+이번 주 회의록을 공유드립니다.
+
+## 주요 논의 사항
+1. 신규 기능 개발 일정 확정
+2. QA 테스트 계획 수립
+3. 다음 스프린트 백로그 정리
+
+## 액션 아이템
+- [ ] 기획서 검토 (홍길동)
+- [ ] API 명세서 작성 (박개발)
+- [ ] 디자인 시안 전달 (이디자인)
+
+감사합니다.`,
+    bodyPreview: '안녕하세요, 홍길동님. 이번 주 회의록을 공유드립니다...',
+    folderId: 'folder-1-1',
+    folderPath: '/업무/프로젝트A',
+    isRead: false,
+    isStarred: true,
+    receivedAt: '2025-12-10T09:30:00Z',
+    classificationReason: '프로젝트A 관련 회의록으로 분류됨',
+  },
+  {
+    id: 'mail-2',
+    subject: 'PR Review 요청: feat/email-classification',
+    from: { name: 'GitHub', email: 'noreply@github.com' },
+    to: [{ name: '홍길동', email: 'user@example.com' }],
+    body: `@developer님이 PR 리뷰를 요청했습니다.
+
+**Pull Request #42**
+feat: LLM 기반 메일 분류 로직 구현
+
+변경 사항:
+- OpenAI API 연동
+- 분류 알고리즘 구현
+- 단위 테스트 추가
+
+[PR 보러가기](https://github.com/example/pigeon/pull/42)`,
+    bodyPreview: '@developer님이 PR 리뷰를 요청했습니다...',
+    folderId: 'folder-1-2',
+    folderPath: '/업무/프로젝트B',
+    isRead: false,
+    isStarred: false,
+    receivedAt: '2025-12-10T08:15:00Z',
+    classificationReason: 'GitHub 알림으로 업무/프로젝트B로 분류됨',
+  },
+  {
+    id: 'mail-3',
+    subject: '주문하신 상품이 배송 완료되었습니다',
+    from: { name: '쿠팡', email: 'no-reply@coupang.com' },
+    to: [{ name: '홍길동', email: 'user@example.com' }],
+    body: `홍길동님, 안녕하세요.
+
+주문하신 상품이 배송 완료되었습니다.
+
+주문번호: 2024121012345
+상품명: 무선 키보드
+배송완료일: 2025-12-10
+
+[배송조회](https://www.coupang.com/tracking/12345)`,
+    bodyPreview: '주문하신 상품이 배송 완료되었습니다...',
+    folderId: 'folder-2-1',
+    folderPath: '/개인/쇼핑',
+    isRead: true,
+    isStarred: false,
+    receivedAt: '2025-12-10T07:00:00Z',
+    classificationReason: '쇼핑몰 배송 알림으로 개인/쇼핑으로 분류됨',
+  },
+  {
+    id: 'mail-4',
+    subject: 'TechNews Weekly #128 - AI 트렌드 총정리',
+    from: { name: 'TechNews', email: 'newsletter@technews.com' },
+    to: [{ name: '홍길동', email: 'user@example.com' }],
+    body: `이번 주 테크 뉴스 하이라이트
+
+## AI 트렌드
+- Claude 4 출시 임박
+- GPT-5 루머 정리
+- 오픈소스 LLM 성능 비교
+
+## 개발자 도구
+- VS Code 새 기능
+- GitHub Copilot 업데이트
+
+[전체 뉴스레터 보기](https://technews.com/weekly/128)`,
+    bodyPreview: '이번 주 테크 뉴스 하이라이트...',
+    folderId: 'folder-3',
+    folderPath: '/뉴스레터',
+    isRead: true,
+    isStarred: false,
+    receivedAt: '2025-12-09T18:00:00Z',
+    classificationReason: '정기 뉴스레터로 분류됨',
+  },
+  {
+    id: 'mail-5',
+    subject: '안녕하세요, 문의드립니다',
+    from: { name: 'Unknown', email: 'unknown@example.org' },
+    to: [{ name: '홍길동', email: 'user@example.com' }],
+    body: `안녕하세요.
+
+일반적인 문의 메일입니다.
+
+감사합니다.`,
+    bodyPreview: '안녕하세요. 일반적인 문의 메일입니다...',
+    folderId: 'folder-4',
+    folderPath: '/미분류',
+    isRead: false,
+    isStarred: false,
+    receivedAt: '2025-12-09T15:30:00Z',
+    classificationReason: '분류 기준에 맞지 않아 미분류로 이동',
+  },
+];
+
+// Mock Sync Status
+export const mockSyncStatus: SyncStatus = {
+  status: 'completed',
+  progress: 100,
+  totalMails: 50,
+  processedMails: 50,
+  lastSyncAt: '2025-12-10T10:00:00Z',
+};
+
+// Helper functions
+export function getMailsByFolderId(folderId: string): Mail[] {
+  return mockMails.filter((mail) => mail.folderId === folderId);
+}
+
+export function getMailById(mailId: string): Mail | undefined {
+  return mockMails.find((mail) => mail.id === mailId);
+}
+
+export function getFolderById(folderId: string): Folder | undefined {
+  const findFolder = (folders: Folder[]): Folder | undefined => {
+    for (const folder of folders) {
+      if (folder.id === folderId) return folder;
+      if (folder.children) {
+        const found = findFolder(folder.children);
+        if (found) return found;
+      }
+    }
+    return undefined;
+  };
+  return findFolder(mockFolders);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ex",
+  "name": "pigeon",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ex",
+      "name": "pigeon",
       "version": "0.1.0",
       "dependencies": {
         "next": "16.0.8",
@@ -19,6 +19,9 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.0.8",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.2.7",
+        "prettier": "^3.7.4",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -2153,6 +2156,35 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
+      "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2571,6 +2603,39 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
+      "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^7.1.0",
+        "string-width": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2596,6 +2661,23 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2819,6 +2901,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-abstract": {
@@ -3445,6 +3540,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3645,6 +3747,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3891,6 +4006,22 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4125,6 +4256,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-generator-function": {
@@ -4788,6 +4935,49 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lint-staged": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
+      "integrity": "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.2",
+        "listr2": "^9.0.5",
+        "micromatch": "^4.0.8",
+        "nano-spawn": "^2.0.0",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4810,6 +5000,26 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -4878,6 +5088,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4907,6 +5130,19 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nano-spawn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
+      "integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -5159,6 +5395,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5286,6 +5538,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -5333,6 +5598,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
+      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {
@@ -5491,6 +5772,23 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -5501,6 +5799,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -5803,6 +6108,49 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5831,6 +6179,33 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -5944,6 +6319,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-bom": {
@@ -6491,12 +6882,84 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
-  "name": "ex",
+  "name": "pigeon",
   "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint . --ext .ts,.tsx",
+    "lint:fix": "eslint . --ext .ts,.tsx --fix",
+    "type-check": "tsc --noEmit",
+    "validate": "npm run lint && npm run type-check && npm run build",
+    "prepare": "husky"
   },
   "dependencies": {
     "next": "16.0.8",
@@ -20,7 +24,19 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.0.8",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.2.7",
+    "prettier": "^3.7.4",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "eslint --fix",
+      "bash -c 'npm run type-check'"
+    ],
+    "*.{js,jsx,ts,tsx,json,css,md}": [
+      "prettier --write --ignore-unknown"
+    ]
   }
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,51 @@
+// User
+export interface User {
+  id: string;
+  email: string;
+  name: string;
+  profileImage?: string;
+}
+
+// Folder
+export interface Folder {
+  id: string;
+  name: string;
+  path: string;
+  parentId: string | null;
+  unreadCount: number;
+  children?: Folder[];
+}
+
+// Mail
+export interface Mail {
+  id: string;
+  subject: string;
+  from: {
+    name: string;
+    email: string;
+  };
+  to: {
+    name: string;
+    email: string;
+  }[];
+  body: string;
+  bodyPreview: string;
+  folderId: string;
+  folderPath: string;
+  isRead: boolean;
+  isStarred: boolean;
+  receivedAt: string;
+  classificationReason?: string;
+}
+
+// Sync Status
+export type SyncStatusType = 'idle' | 'syncing' | 'classifying' | 'completed' | 'error';
+
+export interface SyncStatus {
+  status: SyncStatusType;
+  progress: number;
+  totalMails: number;
+  processedMails: number;
+  lastSyncAt: string | null;
+  errorMessage?: string;
+}


### PR DESCRIPTION
## Summary
- UI 설계 문서(`docs/UI_SPEC.md`) 작성
- 타입 정의(`types/index.ts`) 및 목업 데이터(`lib/mock/data.ts`) 추가
- Pre-commit 훅 설정 (husky + lint-staged)
- Prettier 설정 추가

## Changes
- `docs/UI_SPEC.md`: 화면 구성, 컴포넌트 설계, 목업 데이터, 디자인 시스템
- `types/index.ts`: User, Folder, Mail, SyncStatus 타입 정의
- `lib/mock/data.ts`: 개발용 목업 데이터 및 헬퍼 함수
- `.husky/pre-commit`: lint-staged 실행
- `package.json`: lint, type-check, validate 스크립트 추가
- `.prettierrc`, `.prettierignore`: Prettier 설정

## Test Plan
- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] Pre-commit 훅 동작 확인

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)