### PR TITLE
feat(ui): 랜딩 페이지 및 메일함 3단 레이아웃 구현

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -6,11 +6,7 @@ import { StatusBar } from '@/components/layout/StatusBar';
 import { FolderTree } from '@/components/folder/FolderTree';
 import { mockFolders, mockMails, mockSyncStatus } from '@/lib/mock/data';
 
-export default function MainLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function MainLayout({ children }: { children: React.ReactNode }) {
   const [selectedFolderId, setSelectedFolderId] = useState<string | null>('folder-1-1');
   const [isSyncing, setIsSyncing] = useState(false);
 
@@ -34,9 +30,7 @@ export default function MainLayout({
         </aside>
 
         {/* Main Content */}
-        <main className="flex-1 overflow-hidden">
-          {children}
-        </main>
+        <main className="flex-1 overflow-hidden">{children}</main>
       </div>
 
       <StatusBar syncStatus={mockSyncStatus} totalMails={mockMails.length} />

--- a/app/(main)/mail/page.tsx
+++ b/app/(main)/mail/page.tsx
@@ -31,11 +31,7 @@ export default function MailPage() {
 
       {/* Mail Detail */}
       <div className="flex-1 bg-white">
-        <MailDetail
-          mail={selectedMail}
-          onDelete={handleDelete}
-          onMove={handleMove}
-        />
+        <MailDetail mail={selectedMail} onDelete={handleDelete} onMove={handleMove} />
       </div>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,12 +16,8 @@ export default function Home() {
       <main className="flex-1 flex flex-col items-center justify-center px-6 py-16 bg-gray-50">
         <div className="text-center max-w-2xl">
           <div className="text-6xl mb-6">🕊️</div>
-          <h1 className="text-4xl font-bold text-gray-900 mb-4">
-            AI 메일 폴더링
-          </h1>
-          <p className="text-xl text-gray-600 mb-8">
-            LLM이 당신의 메일을 자동으로 분류해드립니다
-          </p>
+          <h1 className="text-4xl font-bold text-gray-900 mb-4">AI 메일 폴더링</h1>
+          <p className="text-xl text-gray-600 mb-8">LLM이 당신의 메일을 자동으로 분류해드립니다</p>
           <button className="px-8 py-4 text-lg font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors shadow-lg">
             Gmail로 시작하기
           </button>
@@ -39,16 +35,12 @@ export default function Home() {
           <div className="bg-white p-6 rounded-xl shadow-sm border border-gray-200 text-center">
             <div className="text-3xl mb-3">📁</div>
             <h3 className="text-lg font-semibold text-gray-900 mb-2">스마트 폴더</h3>
-            <p className="text-gray-600 text-sm">
-              필요한 폴더 구조를 자동으로 생성하고 관리합니다
-            </p>
+            <p className="text-gray-600 text-sm">필요한 폴더 구조를 자동으로 생성하고 관리합니다</p>
           </div>
           <div className="bg-white p-6 rounded-xl shadow-sm border border-gray-200 text-center">
             <div className="text-3xl mb-3">🔄</div>
             <h3 className="text-lg font-semibold text-gray-900 mb-2">실시간 동기화</h3>
-            <p className="text-gray-600 text-sm">
-              새 메일이 도착하면 즉시 분류하여 알려드립니다
-            </p>
+            <p className="text-gray-600 text-sm">새 메일이 도착하면 즉시 분류하여 알려드립니다</p>
           </div>
         </div>
       </main>

--- a/components/folder/FolderTree.tsx
+++ b/components/folder/FolderTree.tsx
@@ -12,9 +12,7 @@ interface FolderTreeProps {
 export function FolderTree({ folders, selectedFolderId, onSelectFolder }: FolderTreeProps) {
   return (
     <div className="py-2">
-      <div className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase">
-        폴더
-      </div>
+      <div className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase">폴더</div>
       <ul className="space-y-0.5">
         {folders.map((folder) => (
           <FolderTreeItem
@@ -46,9 +44,7 @@ function FolderTreeItem({ folder, selectedFolderId, onSelectFolder, depth }: Fol
     <li>
       <div
         className={`flex items-center gap-1 px-3 py-1.5 cursor-pointer transition-colors ${
-          isSelected
-            ? 'bg-blue-100 text-blue-700'
-            : 'hover:bg-gray-100 text-gray-700'
+          isSelected ? 'bg-blue-100 text-blue-700' : 'hover:bg-gray-100 text-gray-700'
         }`}
         style={{ paddingLeft: `${12 + depth * 16}px` }}
         onClick={() => onSelectFolder(folder.id)}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -34,9 +34,7 @@ export function Header({ onSync, isSyncing = false }: HeaderProps) {
           </div>
         </div>
 
-        <button className="text-sm text-gray-600 hover:text-gray-900">
-          로그아웃
-        </button>
+        <button className="text-sm text-gray-600 hover:text-gray-900">로그아웃</button>
       </div>
     </header>
   );

--- a/components/layout/StatusBar.tsx
+++ b/components/layout/StatusBar.tsx
@@ -44,11 +44,7 @@ export function StatusBar({ syncStatus, totalMails }: StatusBarProps) {
         <span>|</span>
         <span>총 {totalMails}개 메일</span>
       </div>
-      {syncStatus.lastSyncAt && (
-        <div>
-          마지막 확인: {getLastSyncText()}
-        </div>
-      )}
+      {syncStatus.lastSyncAt && <div>마지막 확인: {getLastSyncText()}</div>}
     </footer>
   );
 }

--- a/components/mail/MailDetail.tsx
+++ b/components/mail/MailDetail.tsx
@@ -35,9 +35,7 @@ export function MailDetail({ mail, onMove, onDelete }: MailDetailProps) {
     <div className="flex flex-col h-full">
       {/* Header */}
       <div className="px-6 py-4 border-b border-gray-200">
-        <h2 className="text-xl font-semibold text-gray-900 mb-3">
-          {mail.subject}
-        </h2>
+        <h2 className="text-xl font-semibold text-gray-900 mb-3">{mail.subject}</h2>
         <div className="flex items-center gap-4 text-sm text-gray-600">
           <div>
             <span className="text-gray-500">From:</span>{' '}
@@ -56,9 +54,7 @@ export function MailDetail({ mail, onMove, onDelete }: MailDetailProps) {
             ))}
           </div>
         </div>
-        <div className="text-xs text-gray-500 mt-2">
-          {formatDate(mail.receivedAt)}
-        </div>
+        <div className="text-xs text-gray-500 mt-2">{formatDate(mail.receivedAt)}</div>
       </div>
 
       {/* Body */}

--- a/components/mail/MailList.tsx
+++ b/components/mail/MailList.tsx
@@ -15,9 +15,7 @@ export function MailList({ mails, selectedMailId, onSelectMail }: MailListProps)
       <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-200">
         <input type="checkbox" className="w-4 h-4" />
         <span className="text-sm text-gray-600">전체선택</span>
-        <button className="ml-auto text-sm text-gray-600 hover:text-red-600">
-          🗑️ 삭제
-        </button>
+        <button className="ml-auto text-sm text-gray-600 hover:text-red-600">🗑️ 삭제</button>
       </div>
 
       {/* Mail List */}
@@ -70,31 +68,25 @@ function MailListItem({ mail, isSelected, onSelect }: MailListItemProps) {
       }`}
       onClick={onSelect}
     >
-      <input
-        type="checkbox"
-        className="mt-1 w-4 h-4"
-        onClick={(e) => e.stopPropagation()}
-      />
+      <input type="checkbox" className="mt-1 w-4 h-4" onClick={(e) => e.stopPropagation()} />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <span className={`text-sm ${mail.isRead ? 'text-gray-600' : 'font-semibold text-gray-900'}`}>
+          <span
+            className={`text-sm ${mail.isRead ? 'text-gray-600' : 'font-semibold text-gray-900'}`}
+          >
             {mail.from.name}
           </span>
           {mail.isStarred && <span className="text-yellow-500">⭐</span>}
-          {!mail.isRead && (
-            <span className="w-2 h-2 bg-blue-500 rounded-full" />
-          )}
+          {!mail.isRead && <span className="w-2 h-2 bg-blue-500 rounded-full" />}
         </div>
-        <div className={`text-sm truncate ${mail.isRead ? 'text-gray-600' : 'font-medium text-gray-900'}`}>
+        <div
+          className={`text-sm truncate ${mail.isRead ? 'text-gray-600' : 'font-medium text-gray-900'}`}
+        >
           {mail.subject}
         </div>
-        <div className="text-xs text-gray-500 truncate mt-0.5">
-          {mail.bodyPreview}
-        </div>
+        <div className="text-xs text-gray-500 truncate mt-0.5">{mail.bodyPreview}</div>
       </div>
-      <div className="text-xs text-gray-500 whitespace-nowrap">
-        {formatTime(mail.receivedAt)}
-      </div>
+      <div className="text-xs text-gray-500 whitespace-nowrap">{formatTime(mail.receivedAt)}</div>
     </li>
   );
 }


### PR DESCRIPTION
## Summary
- 랜딩 페이지 (`/`) 구현: 서비스 소개, 기능 카드 3개, CTA 버튼
- 메일함 3단 레이아웃 (`/mail`) 구현: Sidebar + MailList + MailDetail

## Changes
| 파일 | 설명 |
|------|------|
| `app/page.tsx` | 랜딩 페이지 |
| `app/(main)/layout.tsx` | 3단 레이아웃 |
| `app/(main)/mail/page.tsx` | 메일함 페이지 |
| `components/layout/Header.tsx` | 헤더 컴포넌트 |
| `components/layout/StatusBar.tsx` | 상태바 컴포넌트 |
| `components/folder/FolderTree.tsx` | 폴더 트리 컴포넌트 |
| `components/mail/MailList.tsx` | 메일 목록 컴포넌트 |
| `components/mail/MailDetail.tsx` | 메일 상세 컴포넌트 |

## Screenshots
- 랜딩 페이지: 서비스 소개 + 기능 카드
- 메일함: 폴더트리(240px) | 메일목록(360px) | 메일상세(flex-1)

## Test Plan
- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] Playwright로 UI 렌더링 확인

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)